### PR TITLE
Use APE 14 WCS interfact in reproject

### DIFF
--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -3,7 +3,6 @@ import logging
 import warnings
 
 import numpy as np
-from astropy import wcs as fitswcs
 from astropy.modeling import Model
 from astropy import units as u
 import gwcs

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -145,33 +145,23 @@ def reproject(wcs1, wcs2):
         positions in ``wcs1`` and returns x, y positions in ``wcs2``.
     """
 
-    if isinstance(wcs1, fitswcs.WCS):
-        def _trans1(x, y):
-            return wcs1.all_pix2world(x, y, 0)
-        forward_transform = _trans1
-    elif isinstance(wcs1, gwcs.WCS):
-        forward_transform = wcs1.forward_transform
-    elif isinstance(wcs1, fitswcs.wcsapi.SlicedLowLevelWCS):
+    try:
         forward_transform = wcs1.pixel_to_world_values
-    elif issubclass(wcs1, Model):
-        forward_transform = wcs1
-    else:
-        raise TypeError("Expected input to be astropy.wcs.WCS or gwcs.WCS "
-                        "object or astropy.modeling.Model subclass")
+    except AttributeError:
+        if isinstance(wcs1, Model):
+            forward_transform = wcs1
+        else:
+            raise TypeError("Expected input to be of type astropy.wcs.WCS, gwcs.WCS "
+                            f"or astropy.modeling.Model.  Instead it is {type(wcs1)}")
 
-    if isinstance(wcs2, fitswcs.WCS):
-        def _trans2(x, y):
-            return wcs2.all_world2pix(x, y, 0)
-        backward_transform = _trans2
-    elif isinstance(wcs2, gwcs.WCS):
-        backward_transform = wcs2.backward_transform
-    elif isinstance(wcs2, fitswcs.wcsapi.SlicedLowLevelWCS):
+    try:
         backward_transform = wcs2.world_to_pixel_values
-    elif issubclass(wcs2, Model):
-        backward_transform = wcs2.inverse
-    else:
-        raise TypeError("Expected input to be astropy.wcs.WCS or gwcs.WCS "
-                        "object or astropy.modeling.Model subclass")
+    except AttributeError:
+        if isinstance(wcs2, Model):
+            backward_transform = wcs2.inverse
+        else:
+            raise TypeError("Expected input to be of type astropy.wcs.WCS, gwcs.WCS "
+                            f"or astropy.modeling.Model.  Instead it is {type(wcs2)}")
 
     def _reproject(x, y):
         sky = forward_transform(x, y)

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -470,9 +470,10 @@ def test_resample_undefined_variance(nircam_rate, shape):
     im.var_poisson = np.ones(shape, dtype=im.var_poisson.dtype.type)
     im.var_flat = np.ones(shape, dtype=im.var_flat.dtype.type)
     im.meta.filename = "foo.fits"
-
     c = ModelContainer([im])
-    ResampleStep.call(c, blendheaders=False)
+
+    with pytest.warns(RuntimeWarning, match="var_rnoise array not available"):
+        ResampleStep.call(c, blendheaders=False)
 
 
 @pytest.mark.parametrize('ratio', [0.7, 1.2])

--- a/jwst/resample/tests/test_utils.py
+++ b/jwst/resample/tests/test_utils.py
@@ -212,4 +212,4 @@ def test_reproject_with_astropy_model(wcs_gwcs):
 
 def test_reproject_with_garbage_input():
     with pytest.raises(TypeError):
-        f = reproject("foo", "bar")
+        reproject("foo", "bar")

--- a/jwst/resample/tests/test_utils.py
+++ b/jwst/resample/tests/test_utils.py
@@ -195,5 +195,21 @@ def test_reproject(wcs1, wcs2, offset, request):
     
     f = reproject(wcs1, wcs2)
     res = f(x, x)
-    assert_allclose(x, res[0] + offset, atol=0.1, rtol=0)
-    assert_allclose(x, res[1] + offset, atol=0.1, rtol=0)
+    assert_allclose(x, res[0] + offset)
+    assert_allclose(x, res[1] + offset)
+
+
+def test_reproject_with_astropy_model(wcs_gwcs):
+    # Get the astropy.model transform out of the WCS object
+    transform = wcs_gwcs.forward_transform
+    f = reproject(transform, transform)
+    x = np.arange(150, 200)
+
+    res = f(x, x)
+    assert_allclose(x, res[0])
+    assert_allclose(x, res[1])
+
+
+def test_reproject_with_garbage_input():
+    with pytest.raises(TypeError):
+        f = reproject("foo", "bar")


### PR DESCRIPTION
It turns out `reproject()` can use the high-level WCS for all WCS types.  This simplifies the code a bit, and I found a bug in the handling of passing an `astropy.modeling.Model` instance.  There was no test for this, so I added one.

If you're good with this PR, feel free to merge this into your branch.  It will then update your PR against `spacetelescope/jwst` automatically with these updates.  👍 